### PR TITLE
Add ci user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ RUN apk add --no-cache \
         ruby-io-console \
    && curl -o /usr/bin/php-cs-fixer http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar \
    && chmod +x /usr/bin/php-cs-fixer \
-   && ln -s /usr/bin/php-cs-fixer /usr/bin/php-cs-fixer-v2
+   && ln -s /usr/bin/php-cs-fixer /usr/bin/php-cs-fixer-v2 \
+   && addgroup -Sg 1000 ci \
+   && adduser -SG ci -u 1000 -h /src ci

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ This docker image comes with:
 * bash, grep (with pcre, to use `grep -P`) ;
 * ruby, ruby-bundler (to install scss-lint, for instance, with gem or bundle).
 
+
+## Users
+
+By default, this docker image run as the root user.
+
+However, this docker image also define a non-root user `ci` (UID 1000, GID 1000) which can be switched on at run time using the `--user` flag to `docker run`.


### PR DESCRIPTION
By default, this docker image run as the root user. 

However, this PR also add a non-root user `ci` (UID 1000, GID 1000) which can be switched on at runtime.